### PR TITLE
refactor(hc): remove unnecessary code

### DIFF
--- a/hc.zsh
+++ b/hc.zsh
@@ -8,10 +8,6 @@ highlight_cat() {
     return -1
   fi
 
-  if [ $# -eq 0 ]; then
-    cat $@ | highlight --out-format=xterm256 --syntax=js
-  fi
-
   for FNAME in $@
   do
     filename=$(basename "$FNAME")


### PR DESCRIPTION
The if block that test $# does not need to be there.
If there is 0 special parameter, there is no reason to cat.

I would like to know if there any reason why the if condition was here 